### PR TITLE
Implement required attribute (swift)

### DIFF
--- a/maxim.zaks.flattBuffers/src/maxim/zaks/generator/ModelExtensions.xtend
+++ b/maxim.zaks.flattBuffers/src/maxim/zaks/generator/ModelExtensions.xtend
@@ -225,6 +225,11 @@ public class ModelExtensions {
 		field.getAttributes.atributeNames.findFirst[it.deprectated] != null
 	}
 	
+	def isRequired(Field field){
+		if(field.getAttributes == null) return false
+		field.getAttributes.atributeNames.findFirst[it.required] != null
+	}
+	
 	def lengthOfPrimType(String type) {
 		switch type {
 			case 'bool' : 1

--- a/maxim.zaks.flattBuffers/src/maxim/zaks/generator/swift/EagerSwiftGenerator.xtend
+++ b/maxim.zaks.flattBuffers/src/maxim/zaks/generator/swift/EagerSwiftGenerator.xtend
@@ -123,25 +123,31 @@ public class EagerSwiftGenerator {
 		«union.generateCreaterFunctionForUnion»
 	'''
 	
-	def generateMainDataStructureForTable(Table table) '''
+	def generateMainDataStructureForTable(Table table){
+		var visibleFields = table.fields.filter[!it.isDeprecated]
+		var requiredFields = visibleFields.filter[it.isRequired]
+		'''
 		public final class «table.name» {
 			«FOR field : table.fields»
 			public var «field.fieldName» : «field.getType.asSwiftFieldType(!field.isRequired)»«IF !field.isRequired» = «field.defaultValueStringWithVector»«ENDIF»
 			«ENDFOR»
-			public init(«FOR field : table.fields.filter[it.isRequired] SEPARATOR ', '»«field.fieldName»: «field.getType.asSwiftFieldType(false)»«ENDFOR»){
-				«FOR field : table.fields.filter[it.isRequired]»
+			«IF !visibleFields.empty»
+			public init(«FOR field : requiredFields SEPARATOR ', '»«field.fieldName»: «field.getType.asSwiftFieldType(false)»«ENDFOR»){
+				«FOR field : requiredFields»
 				self.«field.fieldName» = «field.fieldName»
 				«ENDFOR»
 			}
-			«IF !table.fields.filter[!it.isDeprecated].empty»
-			public init(«FOR field : table.fields.filter[!it.isDeprecated] SEPARATOR ', '»«field.fieldName»: «field.getType.asSwiftFieldType(!field.isRequired)»«ENDFOR»){
-				«FOR field : table.fields.filter[!it.isDeprecated]»
+			«IF visibleFields.length != requiredFields.length»
+			public init(«FOR field : visibleFields SEPARATOR ', '»«field.fieldName»: «field.getType.asSwiftFieldType(!field.isRequired)»«ENDFOR»){
+				«FOR field : visibleFields»
 				self.«field.fieldName» = «field.fieldName»
 				«ENDFOR»
 			}
 			«ENDIF»
+			«ENDIF»
 		}
-	'''
+		'''
+	}
 	
 	def asSwiftFieldType(Type type){
 		type.asSwiftFieldType(false)


### PR DESCRIPTION
This implements the `(required)` schema attribute in swift by force-unwrapping the properties. Not sure if this is the best way to go about it but it works for my use-case.

 I couldn't get the test suite to run (got a bunch of weird syntax errors and missing modules for `maxim.zaks.flatBuffers.tests`, is there some additional code generation that has to be run there?) so there is probably some cases I haven't covered yet.